### PR TITLE
feat(ci): add GitHub Actions linting with actionlint and zizmor

### DIFF
--- a/.github/workflows/claude-deps-review.yml
+++ b/.github/workflows/claude-deps-review.yml
@@ -21,19 +21,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
 
       - name: Run Claude Dependency Review
         id: claude-deps
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@7145c3e0510bcdbdd29f67cc4a8c1958f1acfa2f # v1.0.27
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: false
           use_vertex: false
-          timeout_minutes: "60"
           prompt: |
             This is an automated dependency update PR from ${{ github.event.pull_request.user.login }}.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,13 +29,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@7145c3e0510bcdbdd29f67cc4a8c1958f1acfa2f # v1.0.27
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -50,4 +51,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,12 +15,15 @@ jobs:
   gitleaks:
     name: Detect Secrets
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,52 @@
+name: Lint GitHub Actions
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@83e4ed25b168066ad8f62f5afbb29ebd8641d982 # v1.69.1
+        with:
+          reporter: github-pr-review
+          fail_level: error
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0

--- a/.github/workflows/test-shell-compatibility.yml
+++ b/.github/workflows/test-shell-compatibility.yml
@@ -27,10 +27,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    
+    permissions:
+      contents: read
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        persist-credentials: false
     
     - name: Install shells on Ubuntu
       if: runner.os == 'Linux'
@@ -48,7 +52,7 @@ jobs:
     - name: Install chezmoi
       run: |
         sh -c "$(curl -fsLS https://get.chezmoi.io)" -- -b "$HOME/.local/bin"
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Configure git
       run: |

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -24,9 +24,13 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        persist-credentials: false
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary
- Add `lint-actions.yml` workflow for GitHub Actions static analysis using actionlint and zizmor
- Harden all existing workflows with security best practices:
  - SHA pinning for supply chain security
  - `persist-credentials: false` to prevent credential leakage
  - Explicit `permissions` blocks for least privilege principle

## Changes
| File | Change |
|------|--------|
| `lint-actions.yml` | New workflow - actionlint (syntax) + zizmor (security/SARIF) |
| `claude-deps-review.yml` | SHA pin, persist-credentials, remove invalid `timeout_minutes` |
| `claude.yml` | SHA pin, persist-credentials |
| `gitleaks.yml` | permissions block, persist-credentials |
| `test-shell-compatibility.yml` | permissions block, persist-credentials |
| `validate-json.yml` | permissions block, persist-credentials |

## Tools
- **[actionlint](https://github.com/rhysd/actionlint)**: Syntax, type checking, runner label validation, shellcheck integration
- **[zizmor](https://github.com/zizmorcore/zizmor)**: Security scanning with SARIF upload to GitHub Security tab

## Test plan
- [x] Run actionlint locally - all checks pass
- [x] Run zizmor locally - "No findings to report"
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)