### PR TITLE
feat(mise): add CI linting tools (uv, actionlint, zizmor)

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -3,6 +3,7 @@ idiomatic_version_file_enable_tools = ["node"]
 experimental = true
 
 [tools]
+actionlint = "1.7.10"
 bun = "1.3.5"
 deno = "2.6.3"
 direnv = "2.37.1"
@@ -11,8 +12,10 @@ go = "1.25.5"
 node = "24.12.0"
 pnpm = "10.26.2"
 rust = "1.92.0"
+uv = "0.9.21"
 yarn = "4.10.3"
 
 # CLI tools (migrated from go install / cargo install)
-"go:github.com/syou6162/git-sequential-stage" = "latest"
 "cargo:similarity-ts" = "=0.4.1"
+"cargo:zizmor" = "=1.19.0"
+"go:github.com/syou6162/git-sequential-stage" = "latest"


### PR DESCRIPTION
## Summary

- Add `uv` (0.9.21) - Python package manager enabling `uvx` command for ad-hoc tool execution
- Add `actionlint` (1.7.10) - Static analysis for GitHub Actions workflows
- Add `zizmor` (=1.19.0) - Security vulnerability scanner for GitHub Actions

These tools support local validation of GitHub Actions workflows before pushing, complementing the recently added CI workflows (ci-shellcheck.yml, ci-typescript.yml).

## Changes

- Alphabetize tool entries for maintainability
- Use exact version pinning (`=`) for cargo-based tools to ensure reproducibility

## Test plan

- [x] Verified tools work in interactive shell: `uvx --version`, `actionlint --version`, `zizmor --version`
- [x] Verified chezmoi apply works correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)