### PR TITLE
Update WSL2 SSH agent PowerShell path

### DIFF
--- a/dot_shell_common/init.sh
+++ b/dot_shell_common/init.sh
@@ -62,7 +62,7 @@ case "$(uname -s)" in
     # WSL detection
     if grep -q microsoft /proc/version 2>/dev/null; then
       if [ -f "$HOME/.local/bin/wsl2-ssh-agent" ]; then
-        eval "$($HOME/.local/bin/wsl2-ssh-agent)"
+        eval "$($HOME/.local/bin/wsl2-ssh-agent -powershell-path pwsh.exe)"
       fi
       export BROWSER=wslview
     fi

--- a/dot_shell_common/windows.sh
+++ b/dot_shell_common/windows.sh
@@ -13,7 +13,7 @@ if [ -z "$SSH_AUTH_SOCK" ]; then
   if [ -f "/proc/version" ] && grep -q "Microsoft" /proc/version; then
     # WSL-specific SSH agent handling
     if [ -f "$HOME/.local/bin/wsl2-ssh-agent" ]; then
-      eval "$($HOME/.local/bin/wsl2-ssh-agent)"
+      eval "$($HOME/.local/bin/wsl2-ssh-agent -powershell-path pwsh.exe)"
     fi
   else
     # MSYS/MINGW/Cygwin SSH agent handling


### PR DESCRIPTION
Use -powershell-path option to explicitly use pwsh.exe (PowerShell 7) instead of the default Windows PowerShell for better compatibility.