### PR TITLE
feat(mise): migrate fzf from chezmoi external to mise management

### DIFF
--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -10,25 +10,6 @@ url = "https://github.com/mame/wsl2-ssh-agent/releases/latest/download/wsl2-ssh-
 refreshPeriod = "24h"
 executable = true
 
-[".local/bin/fzf"]
-  type = "file"
-  url = "https://github.com/junegunn/fzf/releases/download/{{ (gitHubLatestRelease "junegunn/fzf").TagName }}/fzf-{{ trimPrefix "v" (gitHubLatestRelease "junegunn/fzf").TagName }}-{{ .chezmoi.os }}_{{ .chezmoi.arch }}.tar.gz"
-  executable = true
-  refreshPeriod = "168h"
-  [".local/bin/fzf".filter]
-    command = "tar"
-    args = ["--extract", "--file", "/dev/stdin", "--gzip", "--to-stdout", "fzf"]
-
-[".zsh/completions/_fzf"]
-type = "archive"
-url = "https://github.com/junegunn/fzf/archive/master.tar.gz"
-refreshPeriod = "168h"
-stripComponents = 2
-include = ["*/shell/*.zsh"]
-
-[".zsh/functions/fzf-tab-completion.zsh"]
-  type = "file"
-  url = "https://raw.githubusercontent.com/lincheney/fzf-tab-completion/master/zsh/fzf-zsh-completion.sh"
-  refreshPeriod = "168h"
+# fzf is now managed by mise - see ~/.config/mise/config.toml
 {{ end }}
 

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -7,6 +7,7 @@ actionlint = "1.7.10"
 bun = "1.3.5"
 deno = "2.6.3"
 direnv = "2.37.1"
+fzf = "0.67.0"  # Fuzzy finder - migrated from chezmoi external
 gitleaks = "8.30.0"
 go = "1.25.5"
 node = "24.12.0"


### PR DESCRIPTION
## Summary
- Add fzf 0.67.0 to mise config.toml for cross-platform management
- Remove fzf binary and completion downloads from .chezmoiexternal.toml.tmpl
- Fixes template variable expansion error (`<no value>`) in chezmoi external

## Benefits
- ✅ Consistent version management across platforms via mise
- ✅ Avoids chezmoi template variable expansion issues
- ✅ Simplifies dotfiles maintenance

## Testing
- [x] fzf 0.67.0 installed successfully via mise
- [x] `mise ls fzf` shows correct version
- [x] `fzf --version` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)