### PR TITLE
docs: add guideline for document links to ignored files

### DIFF
--- a/dot_claude/.CLAUDE.md
+++ b/dot_claude/.CLAUDE.md
@@ -153,6 +153,22 @@ pnpm build 2>&1 | head -50
 - **完成品**: `docs/` 配下に配置（git管理）
 - **重要な意思決定**: ADRとして記録
 
+### ドキュメント内リンクの原則
+コミット対象の文書（README、docs/配下など）には、以下へのリンクを含めてはならない：
+- **gitignoreされたファイル/ディレクトリ**: `.tmp/`、`node_modules/`、ビルド出力など
+- **プランファイル**: 一時的な作業計画ファイル
+- **ローカル固有のパス**: 絶対パスや環境依存のパス
+
+**対処法**: リンク先の情報が永続的に必要な場合は、`docs/` などgit管理対象の場所に移動してからリンクする。
+
+```
+# ❌ Bad: gitignore対象へのリンク
+詳細は [設計メモ](.tmp/docs/design-notes.md) を参照
+
+# ✅ Good: git管理対象へのリンク
+詳細は [設計メモ](docs/design-notes.md) を参照
+```
+
 **Critical Rule:**
 Always gather evidence (read files, run tests, check actual state) before making decisions. Use **logic-validator** proactively to catch assumption-based reasoning.
 


### PR DESCRIPTION
Add a new principle to prevent linking to gitignored files or temporary
plan files from committed documents. This helps avoid broken links and
ensures documentation remains accessible to all contributors.