### PR TITLE
chore(format): exclude lock files from formatter targets

### DIFF
--- a/.oxfmtignore
+++ b/.oxfmtignore
@@ -4,3 +4,9 @@
 *.toml
 *.sh
 *.tmpl
+
+# Lock files are managed by package managers
+pnpm-lock.yaml
+bun.lock
+package-lock.json
+yarn.lock

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,8 @@
 # Skill templates contain placeholders that break YAML parsers
 .skills/
+
+# Lock files are managed by package managers
+pnpm-lock.yaml
+bun.lock
+package-lock.json
+yarn.lock


### PR DESCRIPTION
Add pnpm-lock.yaml, bun.lock, package-lock.json, and yarn.lock to both
.prettierignore and .oxfmtignore so package-manager-managed lockfiles
are not touched by formatting.

https://claude.ai/code/session_01NfE54xCKyvUsYGkXqjNqFM